### PR TITLE
Fix for the dropdown menu with mobile

### DIFF
--- a/src/main/resources/templates/layout/header.ftlh
+++ b/src/main/resources/templates/layout/header.ftlh
@@ -6,10 +6,12 @@
         <div class="container">
             <#-- Left navbar -->
             <div id="sp-logo-container">
-                <a class="logo" href="${routes.getRouteUrl("showHome")}">
-                    <img src="https://papermc.io/images/logo-marker.svg" alt="Paper logo">
+                <div class="logo">
+                    <a href="${routes.getRouteUrl("showHome")}">
+                        <img src="https://papermc.io/images/logo-marker.svg" alt="Paper logo">
+                    </a>
                     <i class="fas fa-fw fa-chevron-down"></i>
-                </a>
+                </div>
 
                 <div id="sp-logo-menu">
                     <ul id="sp-logo-dropdown">


### PR DESCRIPTION
Retry! I didnt mess the git commits up this time.
This should fix #70
The a href from the logo (the parent of the image and dropdown icon) has been moved to the around the image tag itself.