### PR TITLE
Request-Scoped beans

### DIFF
--- a/src/main/java/io/papermc/hangar/controller/ProjectsController.java
+++ b/src/main/java/io/papermc/hangar/controller/ProjectsController.java
@@ -12,7 +12,6 @@ import io.papermc.hangar.db.dao.ProjectDao;
 import io.papermc.hangar.db.dao.UserDao;
 import io.papermc.hangar.db.model.OrganizationsTable;
 import io.papermc.hangar.db.model.ProjectOwner;
-import io.papermc.hangar.db.model.ProjectVersionsTable;
 import io.papermc.hangar.db.model.ProjectsTable;
 import io.papermc.hangar.db.model.UserProjectRolesTable;
 import io.papermc.hangar.db.model.UsersTable;
@@ -137,15 +136,25 @@ public class ProjectsController extends HangarController {
     @RequestScope
     ProjectsTable projectsTable() {
         Map<String, String> pathParams = (Map<String, String>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
-        if (!pathParams.keySet().containsAll(Set.of("author", "slug"))) {
-            return null;
+        ProjectsTable projectsTable;
+        if (pathParams.keySet().containsAll(Set.of("author", "slug"))) {
+            projectsTable = projectService.getProjectsTable(pathParams.get("author"), pathParams.get("slug"));
+        } else if (pathParams.keySet().contains("pluginId")) {
+            projectsTable = projectService.getProjectsTable(pathParams.get("pluginId"));
         } else {
-            ProjectsTable projectsTable = projectService.getProjectsTable(pathParams.get("author"), pathParams.get("slug"));
-            if (projectsTable == null) {
-                throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-            }
-            return projectsTable;
+            return null;
         }
+        if (projectsTable == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+        }
+        return projectsTable;
+    }
+
+    @Bean
+    @RequestScope
+    ProjectData projectData() {
+        //noinspection SpringConfigurationProxyMethods
+        return projectService.getProjectData(projectsTable());
     }
 
     @Secured("ROLE_USER")

--- a/src/main/java/io/papermc/hangar/controller/VersionsController.java
+++ b/src/main/java/io/papermc/hangar/controller/VersionsController.java
@@ -365,14 +365,14 @@ public class VersionsController extends HangarController {
     @Secured("ROLE_USER")
     @PostMapping("/{author}/{slug}/versions/{version}/approve")
     public ModelAndView approve(@PathVariable String author, @PathVariable String slug, @PathVariable String version) {
-        return _approve(projectVersionsTable.clone(), author, slug, version, false);
+        return _approve(new ProjectVersionsTable(projectVersionsTable), author, slug, version, false);
     }
 
     @GlobalPermission(NamedPermission.REVIEWER)
     @Secured("ROLE_USER")
     @PostMapping("/{author}/{slug}/versions/{version}/approvePartial")
     public ModelAndView approvePartial(@PathVariable String author, @PathVariable String slug, @PathVariable String version) {
-        return _approve(projectVersionsTable.clone(), author, slug, version, true);
+        return _approve(new ProjectVersionsTable(projectVersionsTable), author, slug, version, true);
     }
 
     private ModelAndView _approve(ProjectVersionsTable projectVersion, String author, String slug, String version, boolean partial) {

--- a/src/main/java/io/papermc/hangar/db/dao/ProjectVersionDownloadWarningDao.java
+++ b/src/main/java/io/papermc/hangar/db/dao/ProjectVersionDownloadWarningDao.java
@@ -8,7 +8,6 @@ import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.springframework.stereotype.Repository;
-import org.springframework.stereotype.Service;
 
 import java.net.InetAddress;
 

--- a/src/main/java/io/papermc/hangar/db/model/ProjectVersionsTable.java
+++ b/src/main/java/io/papermc/hangar/db/model/ProjectVersionsTable.java
@@ -5,11 +5,10 @@ import io.papermc.hangar.model.Visibility;
 import io.papermc.hangar.model.generated.ReviewState;
 import org.jdbi.v3.core.enums.EnumByOrdinal;
 
-import java.io.Serializable;
 import java.time.OffsetDateTime;
 import java.util.List;
 
-public class ProjectVersionsTable implements Cloneable {
+public class ProjectVersionsTable {
 
     private long id;
     private OffsetDateTime createdAt;
@@ -29,24 +28,24 @@ public class ProjectVersionsTable implements Cloneable {
     private boolean createForumPost = true;
     private Long postId;
 
-    public ProjectVersionsTable(long id, OffsetDateTime createdAt, String versionString, List<String> dependencies, String description, long projectId, long channelId, long fileSize, String hash, String fileName, Long reviewerId, OffsetDateTime approvedAt, long authorId, Visibility visibility, ReviewState reviewState, boolean createForumPost, Long postId) {
-        this.id = id;
-        this.createdAt = createdAt;
-        this.versionString = versionString;
-        this.dependencies = dependencies;
-        this.description = description;
-        this.projectId = projectId;
-        this.channelId = channelId;
-        this.fileSize = fileSize;
-        this.hash = hash;
-        this.fileName = fileName;
-        this.reviewerId = reviewerId;
-        this.approvedAt = approvedAt;
-        this.authorId = authorId;
-        this.visibility = visibility;
-        this.reviewState = reviewState;
-        this.createForumPost = createForumPost;
-        this.postId = postId;
+    public ProjectVersionsTable(ProjectVersionsTable other) {
+        this.id = other.id;
+        this.createdAt = other.createdAt;
+        this.versionString = other.versionString;
+        this.dependencies = other.dependencies;
+        this.description = other.description;
+        this.projectId = other.projectId;
+        this.channelId = other.channelId;
+        this.fileSize = other.fileSize;
+        this.hash = other.hash;
+        this.fileName = other.fileName;
+        this.reviewerId = other.reviewerId;
+        this.approvedAt = other.approvedAt;
+        this.authorId = other.authorId;
+        this.visibility = other.visibility;
+        this.reviewState = other.reviewState;
+        this.createForumPost = other.createForumPost;
+        this.postId = other.postId;
     }
 
     public ProjectVersionsTable(String versionString, List<String> dependencies, String description, long projectId, long channelId, long fileSize, String hash, String fileName, long authorId, boolean createForumPost) {
@@ -241,28 +240,5 @@ public class ProjectVersionsTable implements Cloneable {
                 ", createForumPost=" + createForumPost +
                 ", postId=" + postId +
                 '}';
-    }
-
-    @Override
-    public ProjectVersionsTable clone() {
-        return new ProjectVersionsTable(
-                id,
-                createdAt,
-                versionString,
-                dependencies,
-                description,
-                projectId,
-                channelId,
-                fileSize,
-                hash,
-                fileName,
-                reviewerId,
-                approvedAt,
-                authorId,
-                visibility,
-                reviewState,
-                createForumPost,
-                postId
-        );
     }
 }

--- a/src/main/java/io/papermc/hangar/db/model/ProjectVersionsTable.java
+++ b/src/main/java/io/papermc/hangar/db/model/ProjectVersionsTable.java
@@ -28,26 +28,6 @@ public class ProjectVersionsTable {
     private boolean createForumPost = true;
     private Long postId;
 
-    public ProjectVersionsTable(ProjectVersionsTable other) {
-        this.id = other.id;
-        this.createdAt = other.createdAt;
-        this.versionString = other.versionString;
-        this.dependencies = other.dependencies;
-        this.description = other.description;
-        this.projectId = other.projectId;
-        this.channelId = other.channelId;
-        this.fileSize = other.fileSize;
-        this.hash = other.hash;
-        this.fileName = other.fileName;
-        this.reviewerId = other.reviewerId;
-        this.approvedAt = other.approvedAt;
-        this.authorId = other.authorId;
-        this.visibility = other.visibility;
-        this.reviewState = other.reviewState;
-        this.createForumPost = other.createForumPost;
-        this.postId = other.postId;
-    }
-
     public ProjectVersionsTable(String versionString, List<String> dependencies, String description, long projectId, long channelId, long fileSize, String hash, String fileName, long authorId, boolean createForumPost) {
         this.versionString = versionString;
         this.dependencies = dependencies;

--- a/src/main/java/io/papermc/hangar/db/model/ProjectVersionsTable.java
+++ b/src/main/java/io/papermc/hangar/db/model/ProjectVersionsTable.java
@@ -5,10 +5,11 @@ import io.papermc.hangar.model.Visibility;
 import io.papermc.hangar.model.generated.ReviewState;
 import org.jdbi.v3.core.enums.EnumByOrdinal;
 
+import java.io.Serializable;
 import java.time.OffsetDateTime;
 import java.util.List;
 
-public class ProjectVersionsTable {
+public class ProjectVersionsTable implements Cloneable {
 
     private long id;
     private OffsetDateTime createdAt;
@@ -27,6 +28,26 @@ public class ProjectVersionsTable {
     private ReviewState reviewState = ReviewState.UNREVIEWED;
     private boolean createForumPost = true;
     private Long postId;
+
+    public ProjectVersionsTable(long id, OffsetDateTime createdAt, String versionString, List<String> dependencies, String description, long projectId, long channelId, long fileSize, String hash, String fileName, Long reviewerId, OffsetDateTime approvedAt, long authorId, Visibility visibility, ReviewState reviewState, boolean createForumPost, Long postId) {
+        this.id = id;
+        this.createdAt = createdAt;
+        this.versionString = versionString;
+        this.dependencies = dependencies;
+        this.description = description;
+        this.projectId = projectId;
+        this.channelId = channelId;
+        this.fileSize = fileSize;
+        this.hash = hash;
+        this.fileName = fileName;
+        this.reviewerId = reviewerId;
+        this.approvedAt = approvedAt;
+        this.authorId = authorId;
+        this.visibility = visibility;
+        this.reviewState = reviewState;
+        this.createForumPost = createForumPost;
+        this.postId = postId;
+    }
 
     public ProjectVersionsTable(String versionString, List<String> dependencies, String description, long projectId, long channelId, long fileSize, String hash, String fileName, long authorId, boolean createForumPost) {
         this.versionString = versionString;
@@ -199,4 +220,49 @@ public class ProjectVersionsTable {
         this.postId = postId;
     }
 
+    @Override
+    public String toString() {
+        return "ProjectVersionsTable{" +
+                "id=" + id +
+                ", createdAt=" + createdAt +
+                ", versionString='" + versionString + '\'' +
+                ", dependencies=" + dependencies +
+                ", description='" + description + '\'' +
+                ", projectId=" + projectId +
+                ", channelId=" + channelId +
+                ", fileSize=" + fileSize +
+                ", hash='" + hash + '\'' +
+                ", fileName='" + fileName + '\'' +
+                ", reviewerId=" + reviewerId +
+                ", approvedAt=" + approvedAt +
+                ", authorId=" + authorId +
+                ", visibility=" + visibility +
+                ", reviewState=" + reviewState +
+                ", createForumPost=" + createForumPost +
+                ", postId=" + postId +
+                '}';
+    }
+
+    @Override
+    public ProjectVersionsTable clone() {
+        return new ProjectVersionsTable(
+                id,
+                createdAt,
+                versionString,
+                dependencies,
+                description,
+                projectId,
+                channelId,
+                fileSize,
+                hash,
+                fileName,
+                reviewerId,
+                approvedAt,
+                authorId,
+                visibility,
+                reviewState,
+                createForumPost,
+                postId
+        );
+    }
 }

--- a/src/main/java/io/papermc/hangar/service/VersionService.java
+++ b/src/main/java/io/papermc/hangar/service/VersionService.java
@@ -110,6 +110,10 @@ public class VersionService {
     public VersionData getVersionData(String author, String slug, String versionString) {
         ProjectData projectData = projectService.getProjectData(author, slug);
         ProjectVersionsTable projectVersion = getVersion(projectData.getProject().getId(), versionString);
+        return getVersionData(projectData, projectVersion);
+    }
+
+    public VersionData getVersionData(ProjectData projectData, ProjectVersionsTable projectVersion) {
         ProjectChannelsTable projectChannel = channelService.getProjectChannel(projectData.getProject().getId(), projectVersion.getChannelId());
         String approvedBy = null;
         if (projectVersion.getReviewerId() != null) {

--- a/src/main/java/io/papermc/hangar/service/project/ProjectService.java
+++ b/src/main/java/io/papermc/hangar/service/project/ProjectService.java
@@ -144,6 +144,10 @@ public class ProjectService {
         return projectDao.get().getBySlug(author, name);
     }
 
+    public ProjectsTable getProjectsTable(String pluginId) {
+        return projectDao.get().getByPluginId(pluginId);
+    }
+
     @Secured("ROLE_USER")
     public void changeVisibility(ProjectsTable project, Visibility newVisibility, String comment) {
         Preconditions.checkNotNull(project, "project");

--- a/src/main/resources/templates/projects/versions/log.ftlh
+++ b/src/main/resources/templates/projects/versions/log.ftlh
@@ -2,13 +2,15 @@
 <#import "*/utils/hangar.ftlh" as hangar />
 <#import "*/layout/base.ftlh" as base />
 
-<#assign message><@spring.messageArgs code="version.log.logger.title" args=[project.namespace] /></#assign>
+<#assign message><@spring.message "version.log.logger.title"/></#assign>
 <@base.base title=message>
     <div class="row">
         <div class="col-md-12">
-            <h1><@spring.message "version.log.visibility.title" /> <a
-                        href="${Routes.VERSIONS_SHOW.getRouteUrl(project.project.name, project.project.slug, version.versionString)}">${project.project.name}
-                    /${project.project.slug}/versions/${version.versionString}</a></h1>
+            <h1><@spring.message "version.log.visibility.title" />
+                <a href="${Routes.VERSIONS_SHOW.getRouteUrl(project.ownerName, project.project.slug, version.versionString)}">
+                    ${project.ownerName}/${project.project.slug}/versions/${version.versionString}
+                </a>
+            </h1>
         </div>
     </div>
     <div class="row">


### PR DESCRIPTION
Take a look at VersionsController and ProjectsController for some examples of bean definitions that could be useful. One drawback is that none of the request-scoped beans will work in any jdbi statement because that is done outside the request scope, so it throws an error. Some solutions are to implement Cloneable (like in ProjectVersionsTable) or have a Copy Constructor, whichever is more popular, just not use @BindBean when updating a row (have separate arguments for each property), or just fetch the table object manually when its later needed in a update statement or something.

Personally, the last option is my least favourite. I like having all the ProjectVersionTables coming from one place. Main reason its good they are all in one place, is so that we can easily handle all not found errors in once spot. And, the bean is only created IF its needed, so its not like its trying to create one every request.

I think option 1 is probably the simplest, although it is annoying to have to create a copy to update it. If there is some other solution to "transferring" that bean outside of the request scope, that'd be best. But I couldn't find anything to that end.