### PR TITLE
Open linkout in same tab

### DIFF
--- a/src/main/resources/templates/projects/view.ftlh
+++ b/src/main/resources/templates/projects/view.ftlh
@@ -188,8 +188,7 @@ Base template for Project overview.
                                 <#if p.project.homepage??>
                                     <#assign homepage=p.project.homepage />
                                     <li id="homepage" class="nav-item">
-                                        <a title="${homepage}" target="_blank" rel="noopener"
-                                           href="${hangar.linkout(homepage)}" class="nav-link">
+                                        <a title="${homepage}" href="${hangar.linkout(homepage)}" class="nav-link">
                                             <i class="fas fa-home"></i> Homepage <i
                                                     class="fas fa-external-link-alt"></i></a>
                                     </li>
@@ -198,8 +197,7 @@ Base template for Project overview.
                                 <#if p.project.issues??>
                                     <#assign issues=p.project.issues />
                                     <li id="issues" class="nav-item">
-                                        <a title="${issues}" target="_blank" rel="noopener"
-                                           href="${hangar.linkout(issues)}" class="nav-link">
+                                        <a title="${issues}" href="${hangar.linkout(issues)}" class="nav-link">
                                             <i class="fas fa-bug"></i> Issues <i
                                                     class="fas fa-external-link-alt"></i></a>
                                     </li>
@@ -208,8 +206,7 @@ Base template for Project overview.
                                 <#if p.project.source??>
                                     <#assign source=p.project.source />
                                     <li id="source" class="nav-item">
-                                        <a title="${source}" target="_blank" rel="noopener"
-                                           href="${hangar.linkout(source)}" class="nav-link">
+                                        <a title="${source}" href="${hangar.linkout(source)}" class="nav-link">
                                             <i class="fas fa-code"></i> Source <i class="fas fa-external-link-alt"></i>
                                         </a>
                                     </li>
@@ -218,8 +215,7 @@ Base template for Project overview.
                                 <#if p.project.support??>
                                     <#assign support=p.project.support />
                                     <li id="support" class="nav-item">
-                                        <a title="${support}" target="_blank" rel="noopener"
-                                           href="${hangar.linkout(support)}" class="nav-link">
+                                        <a title="${support}" href="${hangar.linkout(support)}" class="nav-link">
                                             <i class="fas fa-question-circle"></i> Support <i
                                                     class="fas fa-external-link-alt"></i>
                                         </a>


### PR DESCRIPTION
Open linkout page in the same tab as the current tab, allowing the "go back" link to work correctly.

Should fix #221.